### PR TITLE
fix(smoke): handle pretty JSON output and improve failure diagnostics

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -277,6 +277,33 @@ go test -tags=integration ./cmd/fastplay/...
 go build ./cmd/fastplay
 ```
 
+## Unity Smoke 검증
+
+`fixtures/smoke-project/`에 실제 Unity 설치 환경에서 `fastplay run`의 end-to-end 동작을 검증하는 최소 Unity 프로젝트가 포함되어 있습니다. EditMode 테스트 1개와 PlayMode(`[UnityTest]`) 테스트 1개로 구성됩니다.
+
+**로컬 실행:**
+
+```bash
+# 사전 조건: Unity 설치, UNITY_PATH 설정
+export UNITY_PATH=/Applications/Unity/Hub/Editor/2022.3.0f1/Unity.app/Contents/MacOS/Unity
+./scripts/smoke.sh
+```
+
+스크립트 동작:
+1. EditMode → PlayMode 순으로 각 플랫폼에 맞는 `fastplay.json`을 생성
+2. `fastplay check` + `fastplay run` 실행
+3. 각 run의 아티팩트 디렉터리(`.fastplay/runs/<run_id>/`)에 아래 6개 파일이 모두 존재하는지 확인:
+   - `results.xml`, `summary.json`, `manifest.json`, `stdout.log`, `stderr.log`, `events.ndjson`
+4. 프로젝트 루트의 `fastplay-status.json`(run 디렉터리 바깥의 스냅샷) 존재 확인
+
+**CI (opt-in):**
+
+```bash
+gh workflow run smoke.yml
+```
+
+`.github/workflows/smoke.yml` 참조. Unity가 설치된 self-hosted runner와 `UNITY_PATH` 환경변수가 필요합니다.
+
 ## 라이선스
 
 Apache 2.0 — [LICENSE](LICENSE) 참조.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ export UNITY_PATH=/Applications/Unity/Hub/Editor/2022.3.0f1/Unity.app/Contents/M
 The script:
 1. Writes a `fastplay.json` for each platform (EditMode then PlayMode)
 2. Runs `fastplay check` + `fastplay run`
-3. Verifies `results.xml`, `summary.json`, `manifest.json`, `stdout.log`, `stderr.log`, `events.ndjson` are all present in the run artifact directory
+3. Verifies all 6 run artifacts are present in `.fastplay/runs/<run_id>/`:
+   `results.xml`, `summary.json`, `manifest.json`, `stdout.log`, `stderr.log`, `events.ndjson`
+4. Verifies `fastplay-status.json` exists in the project root (status snapshot, outside the run artifact directory)
 
 **CI (opt-in):**
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -10,11 +10,16 @@
 #   SMOKE_DIR    Path to the smoke Unity project (default: ./fixtures/smoke-project)
 #
 # What this tests:
-#   1. EditMode smoke: fastplay run → exit 0, results.xml, summary.json, manifest.json, events.ndjson
+#   1. EditMode smoke: fastplay run → exit 0, all 6 run artifacts present
 #   2. PlayMode smoke: fastplay run → same artifacts, test_platform=play_mode
 #
+# Artifacts verified per run (inside .fastplay/runs/<run_id>/):
+#   results.xml, summary.json, manifest.json, stdout.log, stderr.log, events.ndjson
+# Snapshot (in smoke project root, outside run artifact dir):
+#   fastplay-status.json
+#
 # The script exits non-zero if any check fails.
-# Dependencies: bash, grep, cut, go — no python3 or jq required.
+# Dependencies: bash, grep, sed, go — no python3 or jq required.
 
 set -euo pipefail
 
@@ -54,19 +59,43 @@ echo "==> Using Unity:      $UNITY_PATH"
 echo "==> Smoke project:    $SMOKE_DIR"
 echo ""
 
-# ── Helper: extract a string field from a single-line JSON object ─────────────
-# Usage: json_str <json> <field>
-# Works with grep+cut — no python3 or jq required.
+# ── Helper: extract a string field from pretty or compact JSON ────────────────
+# Usage: json_str <json_text> <field>
+# Handles both compact  ("field":"value")
+#     and pretty output ("field": "value") from json.MarshalIndent.
+# Returns empty string if the field is not found.
 json_str() {
-  echo "$1" | grep -o "\"$2\":\"[^\"]*\"" | cut -d'"' -f4
+  printf '%s' "$1" \
+    | grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+    | sed 's/.*"[[:space:]]*:[[:space:]]*"//' \
+    | tr -d '"'
 }
 
-# ── Helper: extract a numeric field from a single-line JSON object ────────────
+# ── Helper: extract a numeric field from pretty or compact JSON ───────────────
+# Usage: json_num <json_text> <field>
+# Handles both compact  ("field":0)
+#     and pretty output ("field": 0) from json.MarshalIndent.
+# Returns empty string if the field is not found.
 json_num() {
-  echo "$1" | grep -o "\"$2\":[0-9-]*" | cut -d':' -f2
+  printf '%s' "$1" \
+    | grep -o "\"$2\"[[:space:]]*:[[:space:]]*[0-9-][0-9]*" \
+    | sed 's/.*:[[:space:]]*//'
 }
 
-# ── Helper: generate fastplay.json ───────────────────────────────────────────
+# ── Helper: assert a parsed field is non-empty ────────────────────────────────
+# Usage: assert_field <stage> <field_name> <value> <raw_json>
+# Exits immediately with a diagnostic if the field is empty.
+assert_field() {
+  local stage="$1" field="$2" value="$3" raw="$4"
+  if [[ -z "$value" ]]; then
+    echo "  ERROR [$stage]: field '$field' is empty — JSON parsing failed." >&2
+    echo "  Raw fastplay output:" >&2
+    printf '%s\n' "$raw" | sed 's/^/    /' >&2
+    exit 1
+  fi
+}
+
+# ── Helper: generate fastplay.json for smoke project ─────────────────────────
 
 write_config() {
   local platform="$1"
@@ -84,81 +113,81 @@ write_config() {
 EOF
 }
 
-# ── Helper: verify artifact files exist ──────────────────────────────────────
-
+# ── Helper: verify all expected artifact files are present ───────────────────
+# Usage: check_artifacts <stage> <run_id>
+# Exits immediately if the artifact directory or any expected file is missing.
 check_artifacts() {
-  local run_id="$1"
+  local stage="$1" run_id="$2"
   local artifact_dir="$SMOKE_DIR/.fastplay/runs/$run_id"
 
-  local ok=true
+  if [[ ! -d "$artifact_dir" ]]; then
+    echo "  ERROR [$stage]: artifact directory not found: $artifact_dir" >&2
+    echo "  Possible cause: run_id extraction failed or fastplay did not create the run directory." >&2
+    exit 1
+  fi
+
+  local missing=false
+  # Run artifacts (inside .fastplay/runs/<run_id>/)
   for f in results.xml summary.json manifest.json stdout.log stderr.log events.ndjson; do
     if [[ ! -f "$artifact_dir/$f" ]]; then
-      echo "  MISSING: $artifact_dir/$f" >&2
-      ok=false
+      echo "  MISSING [$stage]: $artifact_dir/$f" >&2
+      missing=true
     fi
   done
+  # Status snapshot (in project root, outside the run artifact dir)
   if [[ ! -f "$SMOKE_DIR/fastplay-status.json" ]]; then
-    echo "  MISSING: $SMOKE_DIR/fastplay-status.json" >&2
-    ok=false
+    echo "  MISSING [$stage]: $SMOKE_DIR/fastplay-status.json (status snapshot)" >&2
+    missing=true
   fi
-  $ok
+  if [[ "$missing" == "true" ]]; then
+    exit 1
+  fi
 }
 
-# ── Smoke 1: EditMode ────────────────────────────────────────────────────────
+# ── Smoke runner ──────────────────────────────────────────────────────────────
+# Usage: run_smoke <stage_label> <platform>
+run_smoke() {
+  local stage="$1" platform="$2"
 
-echo "==> Smoke 1: EditMode"
-write_config "edit_mode"
+  echo "==> $stage ($platform)"
+  write_config "$platform"
+
+  echo "  fastplay check..."
+  "$FASTPLAY" check
+
+  echo "  fastplay run ($platform)..."
+  local output
+  output=$("$FASTPLAY" run)
+
+  local run_id exit_code
+  run_id=$(json_str "$output" "run_id")
+  exit_code=$(json_num "$output" "exit_code")
+
+  assert_field "$stage" "run_id"    "$run_id"    "$output"
+  assert_field "$stage" "exit_code" "$exit_code" "$output"
+
+  echo "  run_id:    $run_id"
+  echo "  exit_code: $exit_code"
+
+  if [[ "$exit_code" != "0" ]]; then
+    echo "  ERROR [$stage]: expected exit_code 0, got $exit_code" >&2
+    echo "  Raw fastplay output:" >&2
+    printf '%s\n' "$output" | sed 's/^/    /' >&2
+    exit 1
+  fi
+
+  echo "  Checking artifacts..."
+  check_artifacts "$stage" "$run_id"
+  echo "  OK"
+  echo ""
+}
+
+# ── Run both smoke stages ─────────────────────────────────────────────────────
 
 cd "$SMOKE_DIR"
 
-echo "  fastplay check..."
-"$FASTPLAY" check
-
-echo "  fastplay run (edit_mode)..."
-output=$("$FASTPLAY" run)
-
-run_id=$(json_str "$output" "run_id")
-exit_code=$(json_num "$output" "exit_code")
-
-echo "  run_id:    $run_id"
-echo "  exit_code: $exit_code"
-
-if [[ "$exit_code" != "0" ]]; then
-  echo "  ERROR: expected exit_code 0, got $exit_code" >&2
-  exit 1
-fi
-
-echo "  Checking artifacts..."
-check_artifacts "$run_id"
-echo "  OK"
-echo ""
-
-# ── Smoke 2: PlayMode ────────────────────────────────────────────────────────
-
-echo "==> Smoke 2: PlayMode"
-write_config "play_mode"
-
-echo "  fastplay check..."
-"$FASTPLAY" check
-
-echo "  fastplay run (play_mode)..."
-output=$("$FASTPLAY" run)
-
-run_id=$(json_str "$output" "run_id")
-exit_code=$(json_num "$output" "exit_code")
-
-echo "  run_id:    $run_id"
-echo "  exit_code: $exit_code"
-
-if [[ "$exit_code" != "0" ]]; then
-  echo "  ERROR: expected exit_code 0, got $exit_code" >&2
-  exit 1
-fi
-
-echo "  Checking artifacts..."
-check_artifacts "$run_id"
-echo "  OK"
-echo ""
+run_smoke "Smoke 1: EditMode" "edit_mode"
+run_smoke "Smoke 2: PlayMode" "play_mode"
 
 # ── Done ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **핵심 버그 수정**: `json_str`/`json_num` 헬퍼가 `json.MarshalIndent` 출력(pretty JSON)을 파싱하지 못하던 문제 수정 — `[[:space:]]*` 패턴 적용으로 pretty/compact 모두 처리
- **실패 진단 개선**: `assert_field()` 추가 — 필드 추출 실패 시 field 이름 + raw JSON 즉시 출력, 조용한 빈 값 진행 차단
- **아티팩트 체크 보강**: `check_artifacts()`에 디렉터리 존재 확인 선행 + 단계 레이블 포함 에러 메시지
- **공통화**: `run_smoke()` 헬퍼로 EditMode/PlayMode 중복 제거
- **README.ko.md 동기화**: Unity Smoke Verification 섹션 추가 (한국어 문서에 누락됐던 Phase B 내용)
- **artifact 목록 통일**: README.md/README.ko.md/smoke.sh 모두 동일한 6개 파일 + fastplay-status.json 스냅샷 설명

## Test Plan

- [ ] `bash -n scripts/smoke.sh` — 구문 오류 없음
- [ ] pretty JSON 샘플로 `json_str`/`json_num` 수동 검증 (run_id, exit_code 정상 추출)
- [ ] compact JSON 샘플로 기존 동작 유지 확인
- [ ] README.ko.md에 smoke 섹션 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)