### PR TITLE
fix(smoke): close set -e failure-path gaps in smoke.sh

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,23 +63,25 @@ echo ""
 # Usage: json_str <json_text> <field>
 # Handles both compact  ("field":"value")
 #     and pretty output ("field": "value") from json.MarshalIndent.
-# Returns empty string if the field is not found.
+# Always returns 0; returns empty string if the field is not found.
+# (|| true prevents grep no-match from triggering set -e / set -o pipefail)
 json_str() {
   printf '%s' "$1" \
     | grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
     | sed 's/.*"[[:space:]]*:[[:space:]]*"//' \
-    | tr -d '"'
+    | tr -d '"' || true
 }
 
 # ── Helper: extract a numeric field from pretty or compact JSON ───────────────
 # Usage: json_num <json_text> <field>
 # Handles both compact  ("field":0)
 #     and pretty output ("field": 0) from json.MarshalIndent.
-# Returns empty string if the field is not found.
+# Always returns 0; returns empty string if the field is not found.
+# (|| true prevents grep no-match from triggering set -e / set -o pipefail)
 json_num() {
   printf '%s' "$1" \
     | grep -o "\"$2\"[[:space:]]*:[[:space:]]*[0-9-][0-9]*" \
-    | sed 's/.*:[[:space:]]*//'
+    | sed 's/.*:[[:space:]]*//' || true
 }
 
 # ── Helper: assert a parsed field is non-empty ────────────────────────────────
@@ -156,25 +158,27 @@ run_smoke() {
   "$FASTPLAY" check
 
   echo "  fastplay run ($platform)..."
-  local output
-  output=$("$FASTPLAY" run)
+  local output cmd_status=0
+  output=$("$FASTPLAY" run) || cmd_status=$?
 
   local run_id exit_code
   run_id=$(json_str "$output" "run_id")
   exit_code=$(json_num "$output" "exit_code")
+
+  if [[ "$cmd_status" -ne 0 ]]; then
+    echo "  ERROR [$stage]: fastplay run exited with status $cmd_status" >&2
+    echo "  run_id:    ${run_id:-(unparsed)}" >&2
+    echo "  exit_code: ${exit_code:-(unparsed)}" >&2
+    echo "  Raw fastplay output:" >&2
+    printf '%s\n' "$output" | sed 's/^/    /' >&2
+    exit 1
+  fi
 
   assert_field "$stage" "run_id"    "$run_id"    "$output"
   assert_field "$stage" "exit_code" "$exit_code" "$output"
 
   echo "  run_id:    $run_id"
   echo "  exit_code: $exit_code"
-
-  if [[ "$exit_code" != "0" ]]; then
-    echo "  ERROR [$stage]: expected exit_code 0, got $exit_code" >&2
-    echo "  Raw fastplay output:" >&2
-    printf '%s\n' "$output" | sed 's/^/    /' >&2
-    exit 1
-  fi
 
   echo "  Checking artifacts..."
   check_artifacts "$stage" "$run_id"


### PR DESCRIPTION
## Summary

- **이슈 1** — `fastplay run` non-zero 시 `set -e`가 진단 코드 전에 스크립트를 종료하던 문제: `output=$("$FASTPLAY" run) || cmd_status=$?` 한 줄로 해결. 이후 `cmd_status != 0` 이면 raw output + 파싱된 필드(또는 `(unparsed)` 폴백) 출력 후 exit.
- **이슈 2** — `json_str`/`json_num`의 `grep` no-match가 `set -euo pipefail` 아래서 스크립트를 종료하던 문제: 파이프라인 끝에 `|| true` 추가. 이제 두 helper는 항상 0을 반환하고 필드 미존재 시 빈 문자열 반환. `assert_field`가 실제 게이트 역할을 하는 구조가 완성됨. 주석도 실제 동작과 일치하도록 수정.
- **이슈 3** — 실패 진단에 프로세스 종료 코드 누락: `cmd_status` (fastplay 프로세스 종료 코드)를 항상 포함, JSON 파싱 성공 여부에 관계없이 raw output 전체 출력.

## Test Plan

- [ ] `bash -n scripts/smoke.sh` — 구문 오류 없음
- [ ] `grep` no-match 상황에서 helper가 빈 문자열 반환하고 스크립트가 죽지 않음 확인
- [ ] `fastplay run` non-zero 시 진단 출력 후 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)