### PR TITLE
fix(shadow): v0.2.0 final — symlink preservation, ctx-aware copy, rollback on failure

### DIFF
--- a/internal/shadow/workspace.go
+++ b/internal/shadow/workspace.go
@@ -39,6 +39,19 @@ func Prepare(ctx context.Context, sourcePath string) (*Workspace, error) {
 	shadowPath := ShadowDir(abs)
 	ws := &Workspace{SourcePath: abs, ShadowPath: shadowPath}
 
+	// Track whether this is a first-time creation so we can clean up on failure.
+	// Refresh calls (workspace already exists) must not roll back Library/ on error.
+	isNew := false
+	if _, statErr := os.Stat(shadowPath); os.IsNotExist(statErr) {
+		isNew = true
+	}
+	succeeded := false
+	defer func() {
+		if isNew && !succeeded {
+			os.RemoveAll(shadowPath)
+		}
+	}()
+
 	if err := os.MkdirAll(shadowPath, 0755); err != nil {
 		return nil, err
 	}
@@ -71,6 +84,7 @@ func Prepare(ctx context.Context, sourcePath string) (*Workspace, error) {
 	// Patch .gitignore — non-fatal.
 	_ = EnsureIgnored(abs, ".fastplay-shadow/")
 
+	succeeded = true
 	return ws, nil
 }
 

--- a/internal/shadow/workspace_test.go
+++ b/internal/shadow/workspace_test.go
@@ -369,6 +369,69 @@ func TestPrepare_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestPrepare_CleansUpOnFirstCreateFailure(t *testing.T) {
+	src := makeProject(t)
+	// Make ProjectSettings/ unreadable so copyDir fails on the second iteration.
+	psDir := filepath.Join(src, "ProjectSettings")
+	if err := os.Chmod(psDir, 0000); err != nil {
+		t.Skipf("cannot chmod on this platform: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(psDir, 0755) })
+
+	shadowPath := filepath.Join(src, ".fastplay-shadow")
+
+	// Confirm shadow does not exist yet (first-create scenario).
+	if _, err := os.Stat(shadowPath); !os.IsNotExist(err) {
+		t.Fatalf("shadow should not exist before Prepare")
+	}
+
+	_, err := shadow.Prepare(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error from unreadable ProjectSettings, got nil")
+	}
+
+	// Shadow workspace must be cleaned up after first-create failure.
+	if _, err := os.Stat(shadowPath); !os.IsNotExist(err) {
+		t.Errorf("expected shadow workspace to be removed after failure, but it still exists")
+	}
+}
+
+func TestPrepare_DoesNotRollbackOnRefreshFailure(t *testing.T) {
+	src := makeProject(t)
+
+	// First successful prepare — establishes the workspace.
+	ws, err := shadow.Prepare(context.Background(), src)
+	if err != nil {
+		t.Fatalf("initial Prepare failed: %v", err)
+	}
+
+	// Write a sentinel file in Library/ to detect it survives.
+	libSentinel := filepath.Join(ws.ShadowPath, "Library", "cached.data")
+	if err := os.WriteFile(libSentinel, []byte("cache"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make ProjectSettings/ unreadable so the refresh copyDir fails.
+	psDir := filepath.Join(src, "ProjectSettings")
+	if err := os.Chmod(psDir, 0000); err != nil {
+		t.Skipf("cannot chmod on this platform: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(psDir, 0755) })
+
+	_, err = shadow.Prepare(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error from unreadable ProjectSettings, got nil")
+	}
+
+	// Shadow workspace must NOT be deleted — Library/ cache must survive.
+	if _, err := os.Stat(ws.ShadowPath); os.IsNotExist(err) {
+		t.Error("shadow workspace was deleted during refresh failure — Library/ cache lost")
+	}
+	if _, err := os.Stat(libSentinel); os.IsNotExist(err) {
+		t.Error("Library/ sentinel was deleted during refresh failure")
+	}
+}
+
 func TestPrepare_CancelsInsideLargeFileCopy(t *testing.T) {
 	projectDir := makeProject(t)
 	// 2 MB file — large enough that io.Copy needs multiple Read calls.


### PR DESCRIPTION
## Summary

- **Symlink preservation** — `copyDir`가 `fs.ModeSymlink`를 감지해 `os.Readlink` + `os.Symlink`로 링크 자체를 복원. 기존에는 심볼릭 링크가 일반 파일로 둔갑하거나(파일 링크) `os.Open` 실패(디렉터리 링크).
- **Context-aware `copyFile`** — `ctxReader` 래퍼 추가. `io.Copy`가 32KB 청크마다 `ctx.Err()`를 체크해 대형 파일 복사 도중 즉시 취소 가능. `copyFile` 시그니처에 `ctx` 추가.
- **에러 시 자동 롤백** — `Prepare` 최초 생성 실패 시 불완전한 `.fastplay-shadow/`를 `defer`로 자동 삭제. 갱신(refresh) 실패 시에는 롤백하지 않아 `Library/` 캐시를 보존.

## Test Plan

- [ ] `TestCopyDir_PreservesSymlink` — 심볼릭 링크가 그대로 복원되는지
- [ ] `TestPrepare_CancelsInsideLargeFileCopy` — 대형 파일 복사 중 ctx 취소 전파
- [ ] `TestPrepare_CleansUpOnFirstCreateFailure` — 최초 생성 실패 시 디렉터리 삭제
- [ ] `TestPrepare_DoesNotRollbackOnRefreshFailure` — 갱신 실패 시 Library/ 캐시 보존
- [ ] `go test ./... -v` — 9개 패키지 전체 통과